### PR TITLE
Improve quiz display and image quality

### DIFF
--- a/src/GamificationGUI.java
+++ b/src/GamificationGUI.java
@@ -80,8 +80,8 @@ public class GamificationGUI {
                 resultArea.setText(sb.toString());
 
                 ImageIcon icon = new ImageIcon(currentUser.getBadgeIconPath());
-                Image img = icon.getImage().getScaledInstance(400, 400, Image.SCALE_SMOOTH);
-                badgeImage.setIcon(new ImageIcon(img));
+                // Display image at natural resolution (no compression)
+                badgeImage.setIcon(icon);
             }
         });
 
@@ -98,8 +98,8 @@ public class GamificationGUI {
         bannerLabel.setHorizontalAlignment(SwingConstants.CENTER);
         String bannerPath = "assets" + File.separator + "badges" + File.separator + "Leaderboard.png";
         ImageIcon bannerIcon = new ImageIcon(bannerPath);
-        Image bannerImg = bannerIcon.getImage().getScaledInstance(400, 400, Image.SCALE_SMOOTH);
-        bannerLabel.setIcon(new ImageIcon(bannerImg));
+        // Display banner at natural resolution (no compression)
+        bannerLabel.setIcon(bannerIcon);
 
         JTextArea leaderboardArea = new JTextArea();
         leaderboardArea.setEditable(false);

--- a/src/LearningModule.java
+++ b/src/LearningModule.java
@@ -82,8 +82,8 @@ public class LearningModule implements ContentProvider {
             return;
         }
         ImageIcon icon = new ImageIcon(pages[currentPage]);
-        Image img = icon.getImage().getScaledInstance(500, 500, Image.SCALE_SMOOTH);
-        imageLabel.setIcon(new ImageIcon(img));
+        // Display image at natural resolution (no compression)
+        imageLabel.setIcon(icon);
         progressBar.setValue(currentPage);
         prevButton.setEnabled(currentPage > 0);
         if (currentPage == totalPages - 1) {

--- a/src/QuizAppGUI.java
+++ b/src/QuizAppGUI.java
@@ -27,7 +27,7 @@ public class QuizAppGUI {
     private void createGUI() {
         frame = new JFrame("Mental Health Quiz");
         frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
-        frame.setSize(540, 1200); 
+        frame.setSize(394, 700); // 9:16 ratio, height capped at 700px
 
         questionArea = new JTextArea(3, 30);
         questionArea.setWrapStyleWord(true);
@@ -113,13 +113,30 @@ public class QuizAppGUI {
         double percentage = quiz.calculateScore();
         String message = quiz.getMotivationalMessage();
 
-        JOptionPane.showMessageDialog(frame,
-                "Your Score: " + score + "\n" +
-                "Percentage: " + percentage + "%\n" +
-                message,
-                "Quiz Results",
-                JOptionPane.INFORMATION_MESSAGE);
-        frame.dispose();
+        JPanel resultPanel = new JPanel();
+        resultPanel.setLayout(new BoxLayout(resultPanel, BoxLayout.Y_AXIS));
+
+        JLabel scoreLabel = new JLabel("Your Score: " + score);
+        scoreLabel.setFont(new Font("Times New Roman", Font.BOLD, 24));
+        JLabel percentageLabel = new JLabel("Percentage: " + percentage + "%");
+        percentageLabel.setFont(new Font("Times New Roman", Font.BOLD, 24));
+
+        JTextArea messageArea = new JTextArea(message);
+        messageArea.setWrapStyleWord(true);
+        messageArea.setLineWrap(true);
+        messageArea.setEditable(false);
+        messageArea.setFont(new Font("Times New Roman", Font.PLAIN, 20));
+
+        resultPanel.add(scoreLabel);
+        resultPanel.add(Box.createVerticalStrut(10));
+        resultPanel.add(percentageLabel);
+        resultPanel.add(Box.createVerticalStrut(10));
+        resultPanel.add(new JScrollPane(messageArea));
+
+        frame.getContentPane().removeAll();
+        frame.getContentPane().add(resultPanel);
+        frame.revalidate();
+        frame.repaint();
     }
 
     private void loadSampleQuestions() {


### PR DESCRIPTION
## Summary
- adjust quiz app window size for 9:16 ratio with 700px height limit
- show quiz results in the main window instead of a dialog
- display images at natural resolution in learning and gamification screens

## Testing
- `javac -cp lib/gson-2.10.1.jar @sources.txt`

------
https://chatgpt.com/codex/tasks/task_e_6853147e7fa8832db5e5f6b3675b96cb