### PR TITLE
Add leaderboard persistence

### DIFF
--- a/src/GamificationEngine.java
+++ b/src/GamificationEngine.java
@@ -24,14 +24,25 @@ import java.util.*;
 public class GamificationEngine implements RewardSystem {
     private List<User> users = new ArrayList<>(); // stores all users who have taken the quiz
     private List<Badge> availableBadges = new ArrayList<>(); // stores the badges the system can assign (Gold, Silver, Bronze, Keep Learning.)
+    private DatabaseHandler dataManager;
 
     public GamificationEngine() {
+        this("scores.txt");
+    }
+
+    public GamificationEngine(String dataFile) {
         // Use File.separator for cross-platform compatibility
         String basePath = "assets" + File.separator + "badges" + File.separator;
         availableBadges.add(new Badge("Gold", basePath + "Gold.png", 15, "Score 15+ points"));
         availableBadges.add(new Badge("Silver", basePath + "Silver.png", 10, "Score 10–14 points"));
         availableBadges.add(new Badge("Bronze", basePath + "Bronze.png", 5, "Score 5–9 points"));
         availableBadges.add(new Badge("Keep Learning", basePath + "Keep_Learning.png", 0, "Less than 5 points"));
+
+        try {
+            dataManager = new DataManager(dataFile);
+        } catch (DataAccessException e) {
+            System.err.println("Could not initialize data manager: " + e.getMessage());
+        }
     }
 
     public void addUser(User user) {
@@ -43,6 +54,15 @@ public class GamificationEngine implements RewardSystem {
         user.awardPoints(points);
         assignBadge(user);
         updateLeaderboard();
+
+        // Persist the user's score if a data manager is available
+        if (dataManager != null) {
+            try {
+                dataManager.appendScore(user.getTotalPoints());
+            } catch (DataAccessException e) {
+                System.err.println("Failed to save score: " + e.getMessage());
+            }
+        }
     }
 
     private void assignBadge(User user) {
@@ -70,12 +90,37 @@ public class GamificationEngine implements RewardSystem {
      */
     public void updateLeaderboard() {
         users.sort((u1, u2) -> u2.getTotalPoints() - u1.getTotalPoints());
+        persistLeaderboard();
     }
 
     public void showLeaderboard() {
         System.out.println("\n🏆 Final Leaderboard:");
         for (User u : users) {
             System.out.println(u.getName() + " - " + u.getTotalPoints() + " pts - Badge: " + u.getBadgeName());
+        }
+    }
+
+    /**
+     * Persist the current leaderboard ordering to the database file.
+     */
+    private void persistLeaderboard() {
+        if (dataManager == null) return;
+
+        StringBuilder sb = new StringBuilder();
+        int rank = 1;
+        for (User u : users) {
+            sb.append(rank++)
+              .append(",")
+              .append(u.getName())
+              .append(",")
+              .append(u.getTotalPoints())
+              .append("\n");
+        }
+
+        try {
+            dataManager.saveData(sb.toString());
+        } catch (DataAccessException e) {
+            System.err.println("Failed to save leaderboard: " + e.getMessage());
         }
     }
 

--- a/src/QuizModule.java
+++ b/src/QuizModule.java
@@ -2,25 +2,35 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+// Data management classes
+
 public class QuizModule implements QuestionHandler {
     public List<Question> questions;
     private int currentScore;
     private int totalQuestions;
     private int timeLimit; // in seconds
     private GamificationEngine engine;
+    private DatabaseHandler dataManager;
 
     public QuizModule(int timeLimit) {
+        this(timeLimit, null, null);
+    }
+
+    public QuizModule(int timeLimit, GamificationEngine engine, DatabaseHandler dataManager) {
         this.timeLimit = timeLimit;
+        this.engine = engine;
+        this.dataManager = dataManager;
         this.questions = new ArrayList<>();
         this.currentScore = 0;
     }
 
     // Constructor used by the gamification GUI
     public QuizModule(GamificationEngine engine) {
-        this.engine = engine;
-        this.timeLimit = 0; // default when not used
-        this.questions = new ArrayList<>();
-        this.currentScore = 0;
+        this(0, engine, null);
+    }
+
+    public QuizModule(GamificationEngine engine, DatabaseHandler dataManager) {
+        this(0, engine, dataManager);
     }
 
     public void addQuestion(Question question) {
@@ -41,6 +51,7 @@ public class QuizModule implements QuestionHandler {
                 currentScore += q.getPoints();
             }
         }
+        persistScore();
         return currentScore;
     }
 
@@ -81,5 +92,17 @@ public class QuizModule implements QuestionHandler {
         if (question instanceof MultipleChoiceQuestion) return "MCQ";
         if (question instanceof TrueFalseQuestion) return "True/False";
         return "Unknown";
+    }
+
+    // Save the current score percentage using the data manager if available
+    private void persistScore() {
+        if (dataManager != null && totalQuestions > 0) {
+            int percentage = (int) Math.round(calculateScore());
+            try {
+                dataManager.appendScore(percentage);
+            } catch (DataAccessException e) {
+                System.err.println("Failed to store score: " + e.getMessage());
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- persist leaderboard order whenever it's updated
- leaderboard entries are saved via `DataManager`

## Testing
- `javac -cp lib/gson-2.10.1.jar src/*.java`

------
https://chatgpt.com/codex/tasks/task_e_6857beed3674832db2e5d14f774cfe35